### PR TITLE
Routes and model binding (Intermediate)

### DIFF
--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -70,6 +70,8 @@
   <ItemGroup>
     <Compile Include="HomeModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Todo.cs" />
+    <Compile Include="TodoModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />

--- a/InstantNancy/ToDoNancy/Todo.cs
+++ b/InstantNancy/ToDoNancy/Todo.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    public class Todo
+    {
+        public long id { get; set; }
+        public string title { get; set; }
+        public int order { get; set; }
+        public bool completed { get; set; }
+    }
+}

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    public class TodoModule
+    {
+        public static Dictionary<long, Todo> store = new Dictionary<long, Todo>();
+    }
+}

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -5,8 +5,35 @@ using System.Web;
 
 namespace ToDoNancy
 {
-    public class TodoModule
+    using Nancy;
+    using Nancy.ModelBinding;
+
+    public class TodoModule : NancyModule
     {
         public static Dictionary<long, Todo> store = new Dictionary<long, Todo>();
+
+        public TodoModule() : base("todos")
+        {
+            Get["/"] = _ => Response.AsJson(store.Values);
+
+            Post["/"] = _ =>
+            {
+                // TodoオブジェクトをPOSTのBodyにバインディング
+                var newTodo = this.Bind<Todo>();
+
+                if (newTodo.id == 0)
+                {
+                    newTodo.id = store.Count + 1;
+                }
+
+                if (store.ContainsKey(newTodo.id)) return HttpStatusCode.NotAcceptable;
+
+                store.Add(newTodo.id, newTodo);
+
+
+                return Response.AsJson(newTodo)
+                    .WithStatusCode(HttpStatusCode.Created);
+            };
+        }
     }
 }

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -30,9 +30,28 @@ namespace ToDoNancy
 
                 store.Add(newTodo.id, newTodo);
 
-
                 return Response.AsJson(newTodo)
                     .WithStatusCode(HttpStatusCode.Created);
+            };
+
+            Put["/{id}"] = p =>
+            {
+                // pはDynamicDictionary型で、インテリセンスは効かない
+                if (!store.ContainsKey(p.id)) return HttpStatusCode.NotFound;
+
+                var updatedTodo = this.Bind<Todo>();
+                store[p.id] = updatedTodo;
+
+                return Response.AsJson(updatedTodo);
+            };
+
+            Delete["/{id}/"] = p =>
+            {
+                if (!store.ContainsKey(p.id)) return HttpStatusCode.NotFound;
+
+                store.Remove(p.id);
+
+                return HttpStatusCode.OK;
             };
         }
     }

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="HomeModuleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TodoModulesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace ToDoNancyTests
 {
+    using CsQuery.ExtensionMethods;
     using Nancy;
     using Nancy.Testing;
     using Xunit;
@@ -78,6 +79,37 @@ namespace ToDoNancyTests
 
             AssertAreSame(aTodo, actualBody[0]);
         }
+
+        [Fact]
+        public void Should_be_able_to_edit_todo_with_put()
+        {
+            var actual = sut.Post("/todos/", with => with.JsonBody(aTodo))
+                .Then
+                .Put("/todos/1", with => with.JsonBody(anEditedTodo))
+                .Then
+                .Get("/todos/");
+
+            var actualBody = actual.Body.DeserializeJson<Todo[]>();
+
+            Assert.Equal(1, actualBody.Length);
+            AssertAreSame(anEditedTodo, actualBody[0]);
+        }
+
+        [Fact]
+        public void Should_be_able_to_delete_todo_with_delete()
+        {
+            // CsQuery.ExtensionMethodsにToJSONメソッドがある
+            var actual = sut.Post("/todos/", with => with.Body(aTodo.ToJSON()))
+                .Then
+                .Delete("/todos/1")
+                .Then
+                .Get("/todos/");
+
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+
+            Assert.Empty(actual.Body.DeserializeJson<Todo[]>());
+        }
+
 
         private void AssertAreSame(Todo expected, Todo actual)
         {

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using Nancy;
+    using Nancy.Testing;
+    using Xunit;
+    using ToDoNancy;
+
+    public class TodoModulesTests
+    {
+        private Browser sut;
+        private Todo aTodo;
+        private Todo anEditedTodo;
+
+        public TodoModulesTests()
+        {
+            TodoModule.store.Clear();
+            sut = new Browser(new DefaultNancyBootstrapper());
+            aTodo = new Todo
+            {
+                title = "task 1",
+                order = 0,
+                completed = false
+            };
+            anEditedTodo = new Todo
+            {
+                id = 42,
+                title = "edited name",
+                order = 0,
+                completed = false
+            };
+        }
+
+        [Fact]
+        public void Should_return_empty_list_on_get_when_no_todos_have_been_posted()
+        {
+            var actual = sut.Get("/todos");
+
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+
+            Assert.Empty(actual.Body.DeserializeJson<Todo[]>());
+        }
+
+        [Fact]
+        public void Should_return_201_create_with_a_todo_is_posted()
+        {
+            var actual = sut.Post("/todos/", with => with.JsonBody(aTodo));
+
+            Assert.Equal(HttpStatusCode.Created, actual.StatusCode);
+        }
+
+        [Fact]
+        public void Should_not_accept_posting_to_with_duplicate_id()
+        {
+            var actual = sut.Post("/todos/", with => with.JsonBody(anEditedTodo))
+                .Then
+                .Post("/todos/", with => with.JsonBody(anEditedTodo));
+
+            Assert.Equal(HttpStatusCode.NotAcceptable, actual.StatusCode);
+        }
+
+        [Fact]
+        public void Should_be_able_to_get_posted_todo()
+        {
+            var actual = sut.Post("/todos/", with => with.JsonBody(aTodo))
+                .Then
+                .Get("/todos/");
+
+            // JSONフォーマットのテキストを、Todoオブジェクトの配列にデシリアライズ
+            var actualBody = actual.Body.DeserializeJson<Todo[]>();
+
+            Assert.Equal(1, actualBody.Length);
+
+            AssertAreSame(aTodo, actualBody[0]);
+        }
+
+        private void AssertAreSame(Todo expected, Todo actual)
+        {
+            Assert.Equal(expected.title, actual.title);
+            Assert.Equal(expected.order, actual.order);
+            Assert.Equal(expected.completed, actual.completed);
+        }
+    }
+}


### PR DESCRIPTION
位置No. 371～
- `public TodoModule() : base("todos")`で、ベースURLを設定
- `this.Bind`を使うためには、 `using Nancy.ModelBinding` を追加
  - [c# - Nancy Model Binding - Stack Overflow](http://stackoverflow.com/questions/22442571/nancy-model-binding)
- 以下のようにしてJSONとレスポンスコードを同時に返す

```
return Response.AsJson(newTodo)
                    .WithStatusCode(HttpStatusCode.Created);
```
- CsQuery.ExtensionMethodsにToJSONメソッドあり
