### PR TITLE
Taking a dependency - introducting the bootstrapper (Intermediate)

### DIFF
--- a/InstantNancy/ToDoNancy/Bootstrapper.cs
+++ b/InstantNancy/ToDoNancy/Bootstrapper.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    using Nancy;
+    
+
+    public class Bootstrapper : DefaultNancyBootstrapper
+    {
+        protected override void ConfigureApplicationContainer(Nancy.TinyIoc.TinyIoCContainer container)
+        {
+            base.ConfigureApplicationContainer(container);
+
+            var mongoDataStore = new MongoDataStore("mongodb://localhost:2700/todos");
+            container.Register<IDataStore>(mongoDataStore);
+        }
+    }
+}

--- a/InstantNancy/ToDoNancy/Bootstrapper.cs
+++ b/InstantNancy/ToDoNancy/Bootstrapper.cs
@@ -14,7 +14,7 @@ namespace ToDoNancy
         {
             base.ConfigureApplicationContainer(container);
 
-            var mongoDataStore = new MongoDataStore("mongodb://localhost:2700/todos");
+            var mongoDataStore = new MongoDataStore("mongodb://localhost:27017/todos");
             container.Register<IDataStore>(mongoDataStore);
         }
     }

--- a/InstantNancy/ToDoNancy/IDataStore.cs
+++ b/InstantNancy/ToDoNancy/IDataStore.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancy
+{
+    public interface IDataStore
+    {
+        IEnumerable<Todo> GetAll();
+        long Count { get; }
+        bool TryAdd(Todo todo);
+        bool TryRemove(int id);
+        bool TryUpdate(Todo todo);
+    }
+}

--- a/InstantNancy/ToDoNancy/MongoDataStore.cs
+++ b/InstantNancy/ToDoNancy/MongoDataStore.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    using MongoDB.Bson;
+    using MongoDB.Driver;
+    using MongoDB.Driver.Builders;
+
+    public class MongoDataStore : IDataStore
+    {
+        private MongoCollection<BsonDocument> todos;
+
+        public MongoDataStore(string connectionString)
+        {
+            // 「MongoDatabase.Createは古い形式です」という警告が出るため、修正
+            // http://stackoverflow.com/questions/7201847/how-to-get-the-mongo-database-specified-in-connection-string-in-c-sharp
+
+            var server = new MongoClient(connectionString).GetServer();
+            var databaseName = MongoUrl.Create(connectionString).DatabaseName;
+            var database = server.GetDatabase(databaseName);
+            todos = database.GetCollection("todos");
+        }
+
+        public long Count { get { return todos.FindAll().Count(); } }
+
+        public IEnumerable<Todo> GetAll()
+        {
+            return todos.FindAllAs<Todo>();
+        }
+
+        public bool TryAdd(Todo todo)
+        {
+            if (FindById(todo.id) != null)
+                return false;
+
+            todos.Insert(todo);
+            return true;
+        }
+
+        public bool TryRemove(int id)
+        {
+            if (FindById(id) == null)
+                return false;
+
+            todos.Remove(Query.EQ("_id", id));
+            return true;
+        }
+
+        private BsonDocument FindById(long id)
+        {
+            return todos.Find(Query.EQ("_id", id)).FirstOrDefault();
+        }
+
+        public bool TryUpdate(Todo todo)
+        {
+            if (FindById(todo.id) == null)
+                return false;
+
+            todos.Save(todo);
+            return true;
+        }
+    }
+}

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -41,6 +41,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    </Reference>
     <Reference Include="Nancy">
       <HintPath>..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
     </Reference>
@@ -68,8 +74,10 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bootstrapper.cs" />
     <Compile Include="HomeModule.cs" />
     <Compile Include="IDataStore.cs" />
+    <Compile Include="MongoDataStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Todo.cs" />
     <Compile Include="TodoModule.cs" />

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HomeModule.cs" />
+    <Compile Include="IDataStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Todo.cs" />
     <Compile Include="TodoModule.cs" />

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -12,7 +12,7 @@ namespace ToDoNancy
     {
         public static Dictionary<long, Todo> store = new Dictionary<long, Todo>();
 
-        public TodoModule() : base("todos")
+        public TodoModule(IDataStore todoStore) : base("todos")
         {
             Get["/"] = _ => Response.AsJson(store.Values);
 

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -14,7 +14,7 @@ namespace ToDoNancy
 
         public TodoModule(IDataStore todoStore) : base("todos")
         {
-            Get["/"] = _ => Response.AsJson(store.Values);
+            Get["/"] = _ => Response.AsJson(todoStore.GetAll());
 
             Post["/"] = _ =>
             {
@@ -34,20 +34,16 @@ namespace ToDoNancy
 
             Put["/{id}"] = p =>
             {
-                // pはDynamicDictionary型で、インテリセンスは効かない
-                if (!store.ContainsKey(p.id)) return HttpStatusCode.NotFound;
-
                 var updatedTodo = this.Bind<Todo>();
-                store[p.id] = updatedTodo;
 
+                if (!todoStore.TryUpdate(updatedTodo)) return HttpStatusCode.NotFound;
+                
                 return Response.AsJson(updatedTodo);
             };
 
             Delete["/{id}/"] = p =>
             {
-                if (!store.ContainsKey(p.id)) return HttpStatusCode.NotFound;
-
-                store.Remove(p.id);
+                if (!todoStore.TryRemove(p.id)) return HttpStatusCode.NotFound;
 
                 return HttpStatusCode.OK;
             };

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -23,13 +23,11 @@ namespace ToDoNancy
 
                 if (newTodo.id == 0)
                 {
-                    newTodo.id = store.Count + 1;
+                    newTodo.id = todoStore.Count + 1;
                 }
 
-                if (store.ContainsKey(newTodo.id)) return HttpStatusCode.NotAcceptable;
-
-                store.Add(newTodo.id, newTodo);
-
+                if (!todoStore.TryAdd(newTodo)) return HttpStatusCode.NotAcceptable;
+                
                 return Response.AsJson(newTodo)
                     .WithStatusCode(HttpStatusCode.Created);
             };

--- a/InstantNancy/ToDoNancy/packages.config
+++ b/InstantNancy/ToDoNancy/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="mongocsharpdriver" version="1.9.2" targetFramework="net45" />
   <package id="Nancy" version="0.23.2" targetFramework="net45" />
   <package id="Nancy.Hosting.Aspnet" version="0.23.2" targetFramework="net45" />
 </packages>

--- a/InstantNancy/ToDoNancyTests/Assertions.cs
+++ b/InstantNancy/ToDoNancyTests/Assertions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using ToDoNancy;
+    using Xunit;
+
+    class Assertions
+    {
+        public static bool AreSame(Todo expected, Todo actual)
+        {
+            Assert.Equal(expected.title, actual.title);
+            Assert.Equal(expected.order, actual.order);
+            Assert.Equal(expected.completed, actual.completed);
+            return true;
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/DataStoreTests.cs
+++ b/InstantNancy/ToDoNancyTests/DataStoreTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace ToDoNancyTests
+{
+    using Nancy.Testing;
+    using FakeItEasy;
+    using Xunit;
+    //using Xunit.Extensions;
+    using ToDoNancy;
+
+
+    public class DataStoreTests
+    {
+        private readonly IDataStore fakeDataStore;
+        private readonly Nancy.Testing.Browser sut;
+        private readonly Todo aTodo;
+
+        public DataStoreTests()
+        {
+            fakeDataStore = FakeItEasy.A.Fake<IDataStore>();
+            sut = new Browser(with =>
+                {
+                    with.Dependency(fakeDataStore);
+                    with.Module<TodoModule>();
+                }
+            );
+
+            aTodo = new Todo()
+            {
+                id = 5,
+                title = "task 10",
+                order = 100,
+                completed = true
+            };
+        }
+
+        [Xunit.Fact]
+        public void Should_store_posted_todos_in_datastore()
+        {
+            sut.Post("/todos/", with => with.JsonBody(aTodo));
+        }
+
+
+        private void AssertCalledTryAddOnDataStoreWith(Todo expected)
+        {
+            // サンプルコードの場合
+            FakeItEasy.A.CallTo(() => fakeDataStore.TryAdd(A<Todo>
+                .That.Matches(actual => ToDoNancyTests.Assertions.AreSame(expected, actual))))
+                .MustHaveHappened();
+
+            // 書籍内コードの場合
+            // 「ステートメント本体を含むラムダ式は、式ツリーに変換できません」のエラーになる
+            //FakeItEasy.A.CallTo(() => fakeDataStore.TryAdd(A<Todo>.That.Matches(actual => 
+            //{
+            //    Assert.Equal(expected.title, actual.title);
+            //    Assert.Equal(expected.order, actual.order);
+            //    Assert.Equal(expected.completed, actual.completed);
+
+            //    return true;
+            //}))).MustHaveHappened();
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/HomeModuleTests.cs
+++ b/InstantNancy/ToDoNancyTests/HomeModuleTests.cs
@@ -9,6 +9,7 @@ namespace ToDoNancyTests
     using Nancy;
     using Nancy.Testing;
     using Xunit;
+    using ToDoNancy;
 
     public class HomeModuleTests
     {
@@ -16,7 +17,7 @@ namespace ToDoNancyTests
         public void Should_answer_200_on_root_path()
         {
             // テスト対象
-            var sut = new Browser(new DefaultNancyBootstrapper());
+            var sut = new Browser(new Bootstrapper());
 
             // 検証対象
             var actual = sut.Get("/");

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -35,6 +35,9 @@
     <Reference Include="CsQuery">
       <HintPath>..\packages\CsQuery.1.3.3\lib\net40\CsQuery.dll</HintPath>
     </Reference>
+    <Reference Include="FakeItEasy">
+      <HintPath>..\packages\FakeItEasy.1.25.1\lib\net40\FakeItEasy.dll</HintPath>
+    </Reference>
     <Reference Include="Nancy">
       <HintPath>..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
     </Reference>
@@ -51,8 +54,13 @@
     <Reference Include="xunit">
       <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
+    <Reference Include="xunit.extensions">
+      <HintPath>..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assertions.cs" />
+    <Compile Include="DataStoreTests.cs" />
     <Compile Include="HomeModuleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TodoModulesTests.cs" />

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -38,6 +38,12 @@
     <Reference Include="FakeItEasy">
       <HintPath>..\packages\FakeItEasy.1.25.1\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    </Reference>
     <Reference Include="Nancy">
       <HintPath>..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
     </Reference>

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -10,6 +10,7 @@ namespace ToDoNancyTests
     using Nancy;
     using Nancy.Testing;
     using Xunit;
+    using MongoDB.Driver;
     using ToDoNancy;
 
     public class TodoModulesTests
@@ -20,8 +21,14 @@ namespace ToDoNancyTests
 
         public TodoModulesTests()
         {
-            TodoModule.store.Clear();
-            sut = new Browser(new DefaultNancyBootstrapper());
+            var connectionString = "mongodb://localhost:27017/todos";
+            var server = new MongoClient(connectionString).GetServer();
+            var databaseName = MongoUrl.Create(connectionString).DatabaseName;
+            var database = server.GetDatabase(databaseName);
+
+            database.Drop();
+
+            sut = new Browser(new Bootstrapper());
             aTodo = new Todo
             {
                 title = "task 1",

--- a/InstantNancy/ToDoNancyTests/packages.config
+++ b/InstantNancy/ToDoNancyTests/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsQuery" version="1.3.3" targetFramework="net45" />
+  <package id="FakeItEasy" version="1.25.1" targetFramework="net45" />
   <package id="Nancy" version="0.23.2" targetFramework="net45" />
   <package id="Nancy.Testing" version="0.23.2" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/InstantNancy/ToDoNancyTests/packages.config
+++ b/InstantNancy/ToDoNancyTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="CsQuery" version="1.3.3" targetFramework="net45" />
   <package id="FakeItEasy" version="1.25.1" targetFramework="net45" />
+  <package id="mongocsharpdriver" version="1.9.2" targetFramework="net45" />
   <package id="Nancy" version="0.23.2" targetFramework="net45" />
   <package id="Nancy.Testing" version="0.23.2" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />


### PR DESCRIPTION
位置No.463～
- モックライブラリである、NuGet `FakeItEasy` の追加
- MongoDBドライバーのNuGet `mongocsharpdriver` の追加
- 位置No.477の `AssertCalledTryAddOnDataStoreWith` メソッドが書籍とサンプルコードで異なる
  - 書籍ではコンパイルできないので、サンプルコードの方を使う
  - ToDoNancyTestsプロジェクトに、`Assertions`クラスを追加
- 位置No.504のテストコードがサンプルコードに残っていないため、IDataStoreを使った方法がわからない
  - サンプルコードは最終形しか残されていない
- MongoDataStoreクラスで使っている`MongoDatabase.Create`が古いため、`MongoClient`を使う方法へと変更
  - [mongodb - How to get the Mongo database specified in connection string in C# - Stack Overflow](http://stackoverflow.com/questions/7201847/how-to-get-the-mongo-database-specified-in-connection-string-in-c-sharp)
- 位置No.537にて、`var mongoDataStore`でポート`27010`としているが、`27017`のtypo
- NancyのデフォルトDIコンテナは`TinyIoC`で、Bootstrapperで使われている
  - Bootstrapperにて、`Castle Windsor`, `StructureMap`, `Autofac`, `Unity`, `Ninject` などへの切り替えも可能
#### MongoDBのインストール

参考：[[MogoDB]MongoDBをWindows環境にインストールする - Netplanetes](http://handcraft.blogsite.org/Memo/Article/Archives/562)
- Windows x64版 (現時点では、2.6.7)
- インストール先： `C:\mongodb`
- ポートをオープン
  - デフォルトポート：[Default MongoDB Port — MongoDB Manual 2.6.7](http://docs.mongodb.org/manual/reference/default-mongodb-port)
  - 開け方：[Configure Windows netsh Firewall for MongoDB — MongoDB Manual 2.6.7](http://docs.mongodb.org/manual/tutorial/configure-windows-netsh-firewall)
- DB用のディレクトリを `C:\mongodb\data\db` として作成
- 起動： `C:\mongodb\bin\mongod.exe --dbpath C:\mongodb\data\db`
- 停止： `Ctrl + C`
