### PR TITLE
Content negotiation and more model binding(Advanced)

### DIFF
--- a/InstantNancy/ToDoNancy/ProtoBufProcessor.cs
+++ b/InstantNancy/ToDoNancy/ProtoBufProcessor.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Nancy;
+    using Nancy.ModelBinding;
+    using Nancy.Responses.Negotiation;
+    using ProtoBuf;
+
+    public class ProtoBufProcessor : IResponseProcessor
+    {
+        public ProcessorMatch CanProcess(MediaRange requestedMediaRange, dynamic model, NancyContext context)
+        {
+            // MediaRange.FromString(string)は古い形式です： Please use the constructor
+            if (requestedMediaRange.Matches(new MediaRange("application/x-protobuf")))
+            //if (requestedMediaRange.Matches(MediaRange.FromString("application/x-protobuf")))
+                return new ProcessorMatch { ModelResult = MatchResult.DontCare, RequestedContentTypeResult = MatchResult.ExactMatch };
+
+            if (requestedMediaRange.Subtype.ToString().EndsWith("protobuf"))
+                return new ProcessorMatch { ModelResult = MatchResult.DontCare, RequestedContentTypeResult = MatchResult.NonExactMatch };
+
+            return new ProcessorMatch { ModelResult = MatchResult.DontCare, RequestedContentTypeResult = MatchResult.NoMatch };
+        }
+
+        public Response Process(MediaRange requestedMediaRange, dynamic model, NancyContext context)
+        {
+            return new Response
+            {
+                Contents = stream => Serializer.Serialize(stream, model),
+                ContentType = "application/x-protobuf"
+            };
+        }
+
+        public IEnumerable<Tuple<string, MediaRange>> ExtensionMappings
+        {
+            get { return new[] { new Tuple<string, MediaRange>(".protobuf", new MediaRange("application/x-protobuf")) }; }
+            //get { return new[] { new Tuple<string, MediaRange>(".protobuf", MediaRange.FromString("application/x-protobuf")) }; }
+        }
+    }
+
+    public class ProtobufBodyDeserializer : IBodyDeserializer
+    {
+        // Interfaceの要件を満たすため、引数に`BindingContext`を追加
+        public bool CanDeserialize(string contentType, BindingContext content)
+        {
+            return contentType == "application/x-protobuf";
+        }
+
+        public object Deserialize(string contentType, Stream bodyStream, BindingContext context)
+        {
+            return Serializer.NonGeneric.Deserialize(context.DestinationType, bodyStream);
+        }
+    }
+}

--- a/InstantNancy/ToDoNancy/ProtoBufProcessor.cs
+++ b/InstantNancy/ToDoNancy/ProtoBufProcessor.cs
@@ -39,6 +39,7 @@ namespace ToDoNancy
 
         public IEnumerable<Tuple<string, MediaRange>> ExtensionMappings
         {
+            // MediaRange.FromString(string)は古い形式です： Please use the constructor
             get { return new[] { new Tuple<string, MediaRange>(".protobuf", new MediaRange("application/x-protobuf")) }; }
             //get { return new[] { new Tuple<string, MediaRange>(".protobuf", MediaRange.FromString("application/x-protobuf")) }; }
         }

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -53,6 +53,9 @@
     <Reference Include="Nancy.Hosting.Aspnet">
       <HintPath>..\packages\Nancy.Hosting.Aspnet.0.23.2\lib\net40\Nancy.Hosting.Aspnet.dll</HintPath>
     </Reference>
+    <Reference Include="protobuf-net">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -82,6 +82,7 @@
     <Compile Include="IDataStore.cs" />
     <Compile Include="MongoDataStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ProtoBufProcessor.cs" />
     <Compile Include="Todo.cs" />
     <Compile Include="TodoModule.cs" />
   </ItemGroup>

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -14,7 +14,7 @@ namespace ToDoNancy
 
         public TodoModule(IDataStore todoStore) : base("todos")
         {
-            Get["/"] = _ => Response.AsJson(todoStore.GetAll());
+            Get["/"] = _ => todoStore.GetAll();
 
             Post["/"] = _ =>
             {

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -7,6 +7,7 @@ namespace ToDoNancy
 {
     using Nancy;
     using Nancy.ModelBinding;
+    using Nancy.Responses.Negotiation;
 
     public class TodoModule : NancyModule
     {

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -27,8 +27,9 @@ namespace ToDoNancy
                 }
 
                 if (!todoStore.TryAdd(newTodo)) return HttpStatusCode.NotAcceptable;
-                
-                return Response.AsJson(newTodo)
+
+                return Negotiate
+                    .WithModel(newTodo)
                     .WithStatusCode(HttpStatusCode.Created);
             };
 

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -38,8 +38,8 @@ namespace ToDoNancy
                 var updatedTodo = this.Bind<Todo>();
 
                 if (!todoStore.TryUpdate(updatedTodo)) return HttpStatusCode.NotFound;
-                
-                return Response.AsJson(updatedTodo);
+
+                return updatedTodo;
             };
 
             Delete["/{id}/"] = p =>

--- a/InstantNancy/ToDoNancy/packages.config
+++ b/InstantNancy/ToDoNancy/packages.config
@@ -3,4 +3,5 @@
   <package id="mongocsharpdriver" version="1.9.2" targetFramework="net45" />
   <package id="Nancy" version="0.23.2" targetFramework="net45" />
   <package id="Nancy.Hosting.Aspnet" version="0.23.2" targetFramework="net45" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
 </packages>

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -50,6 +50,9 @@
     <Reference Include="Nancy.Testing">
       <HintPath>..\packages\Nancy.Testing.0.23.2\lib\net40\Nancy.Testing.dll</HintPath>
     </Reference>
+    <Reference Include="protobuf-net">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -63,6 +63,20 @@ namespace ToDoNancyTests
         }
 
         [Fact]
+        public void Should_return_created_todo_as_xml_when_a_todo_is_posted()
+        {
+            var actual = sut.Post("/todos/", with =>
+            {
+                with.JsonBody(aTodo);
+                with.Accept("applicatoin/xml");
+            });
+
+            var actualBody = actual.Body.DeserializeXml<Todo>();
+
+            Assertions.AreSame(aTodo, actualBody);
+        }
+
+        [Fact]
         public void Should_not_accept_posting_to_with_duplicate_id()
         {
             var actual = sut.Post("/todos/", with => with.JsonBody(anEditedTodo))

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -47,7 +47,7 @@ namespace ToDoNancyTests
         [Fact]
         public void Should_return_empty_list_on_get_when_no_todos_have_been_posted()
         {
-            var actual = sut.Get("/todos");
+            var actual = sut.Get("/todos", with => with.Accept("application/xml"));
 
             Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
 
@@ -77,7 +77,7 @@ namespace ToDoNancyTests
         {
             var actual = sut.Post("/todos/", with => with.JsonBody(aTodo))
                 .Then
-                .Get("/todos/");
+                .Get("/todos/", with => with.Accept("application/xml"));
 
             // JSONフォーマットのテキストを、Todoオブジェクトの配列にデシリアライズ
             var actualBody = actual.Body.DeserializeJson<Todo[]>();
@@ -94,7 +94,7 @@ namespace ToDoNancyTests
                 .Then
                 .Put("/todos/1", with => with.JsonBody(anEditedTodo))
                 .Then
-                .Get("/todos/");
+                .Get("/todos/", with => with.Accept("application/xml"));
 
             var actualBody = actual.Body.DeserializeJson<Todo[]>();
 
@@ -110,7 +110,7 @@ namespace ToDoNancyTests
                 .Then
                 .Delete("/todos/1")
                 .Then
-                .Get("/todos/");
+                .Get("/todos/", with => with.Accept("application/xml"));
 
             Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
 
@@ -148,6 +148,8 @@ namespace ToDoNancyTests
             Assert.Equal(1, actualBody.Length);
             Assertions.AreSame(aTodo, actualBody[0]);
         }
+
+        
 
 
         //---------------

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -47,19 +47,36 @@ namespace ToDoNancyTests
         [Fact]
         public void Should_return_empty_list_on_get_when_no_todos_have_been_posted()
         {
-            var actual = sut.Get("/todos", with => with.Accept("application/xml"));
+            var actual = sut.Get("/todos", with => with.Accept("application/json"));
 
             Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
-
             Assert.Empty(actual.Body.DeserializeJson<Todo[]>());
         }
 
         [Fact]
         public void Should_return_201_create_with_a_todo_is_posted()
         {
-            var actual = sut.Post("/todos/", with => with.JsonBody(aTodo));
+            var actual = sut.Post("/todos/", with =>
+            {
+                with.JsonBody(aTodo);
+                with.Accept("application/json");
+            });
 
             Assert.Equal(HttpStatusCode.Created, actual.StatusCode);
+        }
+
+        [Fact]
+        public void Should_return_created_todo_as_json_when_a_todo_is_posted()
+        {
+            var actual = sut.Post("/todos/",
+              with =>
+              {
+                  with.JsonBody(aTodo);
+                  with.Accept("application/json");
+              });
+
+            var actualBody = actual.Body.DeserializeJson<Todo>();
+            Assertions.AreSame(aTodo, actualBody);
         }
 
         [Fact]
@@ -68,9 +85,8 @@ namespace ToDoNancyTests
             var actual = sut.Post("/todos/", with =>
             {
                 with.JsonBody(aTodo);
-                with.Accept("applicatoin/xml");
+                with.Accept("application/xml");
             });
-
             var actualBody = actual.Body.DeserializeXml<Todo>();
 
             Assertions.AreSame(aTodo, actualBody);
@@ -79,9 +95,15 @@ namespace ToDoNancyTests
         [Fact]
         public void Should_not_accept_posting_to_with_duplicate_id()
         {
-            var actual = sut.Post("/todos/", with => with.JsonBody(anEditedTodo))
+            var actual = sut.Post("/todos/", with => {
+                    with.JsonBody(anEditedTodo);
+                    with.Accept("application/json");
+                })
                 .Then
-                .Post("/todos/", with => with.JsonBody(anEditedTodo));
+                .Post("/todos/", with => {
+                    with.JsonBody(anEditedTodo);
+                    with.Accept("application/json");
+                });
 
             Assert.Equal(HttpStatusCode.NotAcceptable, actual.StatusCode);
         }
@@ -89,46 +111,39 @@ namespace ToDoNancyTests
         [Fact]
         public void Should_be_able_to_get_posted_todo()
         {
-            var actual = sut.Post("/todos/", with => with.JsonBody(aTodo))
+            var actual = sut.Post("/todos/", with => {
+                with.JsonBody(aTodo);
+                with.Accept("application/json");
+                })
                 .Then
-                .Get("/todos/", with => with.Accept("application/xml"));
+                .Get("/todos/", with => with.Accept("application/json"));
 
             // JSONフォーマットのテキストを、Todoオブジェクトの配列にデシリアライズ
             var actualBody = actual.Body.DeserializeJson<Todo[]>();
 
             Assert.Equal(1, actualBody.Length);
-
             AssertAreSame(aTodo, actualBody[0]);
         }
 
         [Fact]
         public void Should_be_able_to_edit_todo_with_put()
         {
-            var actual = sut.Post("/todos/", with => with.JsonBody(aTodo))
-                .Then
-                .Put("/todos/1", with => with.JsonBody(anEditedTodo))
-                .Then
-                .Get("/todos/", with => with.Accept("application/xml"));
+            var actual = sut.Post("/todos/", with => {
+                with.JsonBody(aTodo);
+                with.Accept("application/json");
+            })
+            .Then
+            .Put("/todos/1", with => {
+                with.JsonBody(anEditedTodo);
+                with.Accept("application/json");
+            })
+            .Then
+            .Get("/todos/", with => with.Accept("application/json"));
 
             var actualBody = actual.Body.DeserializeJson<Todo[]>();
 
             Assert.Equal(1, actualBody.Length);
             AssertAreSame(anEditedTodo, actualBody[0]);
-        }
-
-        [Fact]
-        public void Should_be_able_to_delete_todo_with_delete()
-        {
-            // CsQuery.ExtensionMethodsにToJSONメソッドがある
-            var actual = sut.Post("/todos/", with => with.Body(aTodo.ToJSON()))
-                .Then
-                .Delete("/todos/1")
-                .Then
-                .Get("/todos/", with => with.Accept("application/xml"));
-
-            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
-
-            Assert.Empty(actual.Body.DeserializeJson<Todo[]>());
         }
 
         [Fact]
@@ -148,6 +163,7 @@ namespace ToDoNancyTests
             AssertAreSame(aTodo, actualBody[0]);
         }
 
+        // Cannot pass
         [Fact]
         public void Should_be_able_to_get_posted_todo_as_xml()
         {
@@ -155,8 +171,13 @@ namespace ToDoNancyTests
             {
                 with.XMLBody(aTodo);
                 with.Accept("application/xml");
-            });
+            })
+            .Then
+            .Get("/todos/", with => with.Accept("application/xml"));
 
+            // !! System.InvalidOperationException !!
+            // 追加情報:XML シリアル化を可能にするには、IEnumerable から継承される型は、継承階層のすべてのレベルで Add(System.Object) が実装される必要があります。
+            // MongoDB.Driver.MongoCursor`1[[ToDoNancy.Todo, ToDoNancy, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] には Add(System.Object) が実装されていません。
             var actualBody = actual.Body.DeserializeXml<Todo[]>();
 
             Assert.Equal(1, actualBody.Length);
@@ -166,7 +187,8 @@ namespace ToDoNancyTests
         [Fact]
         public void Should_be_able_to_get_posted_todo_as_protobuf()
         {
-            var actual = sut.Put("/todos/", with => {
+            var actual = sut.Put("/todos/", with =>
+            {
                 var stream = new System.IO.MemoryStream();
                 ProtoBuf.Serializer.Serialize(stream, aTodo);
                 with.Body(stream, "application/x-protobuf");
@@ -175,10 +197,46 @@ namespace ToDoNancyTests
             .Then
             .Get("/todos/", with => with.Accept("application/x-protobuf"));
 
+            // !! System.InvalidOperationException !!
+            // Type is not expected. and no contract can be inferred: ToDoNancy.Todo
             var actualBody = ProtoBuf.Serializer.Deserialize<Todo[]>(actual.Body.AsStream());
 
             Assert.Equal(1, actualBody.Length);
             Assertions.AreSame(aTodo, actualBody[0]);
+        }
+
+        [Fact]
+        public void Should_be_able_to_delete_todo_with_delete()
+        {
+            // CsQuery.ExtensionMethodsにToJSONメソッドがある
+            var actual = sut.Post("/todos/", with =>
+            {
+                with.Body(aTodo.ToJSON());
+                with.Accept("application/json");
+            })
+            .Then
+            .Delete("/todos/1")
+            .Then
+            .Get("/todos/", with => with.Accept("application/json"));
+
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+            Assert.Empty(actual.Body.DeserializeJson<Todo[]>());
+        }
+
+        [Fact]
+        public void Should_support_head()
+        {
+            var actual = sut.Head("/todos/", with => with.Accept("application/json"));
+
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+        }
+
+        [Fact]
+        public void Should_support_options()
+        {
+            var actual = sut.Options("/todos/");
+
+            Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
         }
 
 

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -134,6 +134,20 @@ namespace ToDoNancyTests
             AssertAreSame(aTodo, actualBody[0]);
         }
 
+        [Fact]
+        public void Should_be_able_to_get_posted_todo_as_xml()
+        {
+            var actual = sut.Post("/todos/", with =>
+            {
+                with.XMLBody(aTodo);
+                with.Accept("application/xml");
+            });
+
+            var actualBody = actual.Body.DeserializeXml<Todo[]>();
+
+            Assert.Equal(1, actualBody.Length);
+            Assertions.AreSame(aTodo, actualBody[0]);
+        }
 
 
         //---------------

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -163,7 +163,23 @@ namespace ToDoNancyTests
             Assertions.AreSame(aTodo, actualBody[0]);
         }
 
-        
+        [Fact]
+        public void Should_be_able_to_get_posted_todo_as_protobuf()
+        {
+            var actual = sut.Put("/todos/", with => {
+                var stream = new System.IO.MemoryStream();
+                ProtoBuf.Serializer.Serialize(stream, aTodo);
+                with.Body(stream, "application/x-protobuf");
+                with.Accept("application/xml");
+            })
+            .Then
+            .Get("/todos/", with => with.Accept("application/x-protobuf"));
+
+            var actualBody = ProtoBuf.Serializer.Deserialize<Todo[]>(actual.Body.AsStream());
+
+            Assert.Equal(1, actualBody.Length);
+            Assertions.AreSame(aTodo, actualBody[0]);
+        }
 
 
         //---------------

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -117,6 +117,26 @@ namespace ToDoNancyTests
             Assert.Empty(actual.Body.DeserializeJson<Todo[]>());
         }
 
+        [Fact]
+        public void Should_be_able_to_get_posted_xml_todo()
+        {
+            var actual = sut.Post("/todos/", with =>
+            {
+                with.XMLBody(aTodo);
+                with.Accept("application/xml");
+            })
+            .Then
+            .Get("todos/", with => with.Accept("application/json"));
+
+            var actualBody = actual.Body.DeserializeJson<Todo[]>();
+
+            Assert.Equal(1, actualBody.Length);
+            AssertAreSame(aTodo, actualBody[0]);
+        }
+
+
+
+        //---------------
 
         private void AssertAreSame(Todo expected, Todo actual)
         {

--- a/InstantNancy/ToDoNancyTests/packages.config
+++ b/InstantNancy/ToDoNancyTests/packages.config
@@ -5,6 +5,7 @@
   <package id="mongocsharpdriver" version="1.9.2" targetFramework="net45" />
   <package id="Nancy" version="0.23.2" targetFramework="net45" />
   <package id="Nancy.Testing" version="0.23.2" targetFramework="net45" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
位置No.566～
- 位置No.595の6.以降、テスト自体がException
  - System.InvaridOperationException
  - サンプルコードを見ても、本文と差異ありのため、このまま進める
    - 本文は`application/xml`だが、サンプルコードは`application/json`
- 位置No.657の`CanDeserialize`メソッドがインタフェース`IBodyDeserializer`の要件を満たさない
  - メソッドの引数に`BindingContext`を追加
- 位置No.657の`MediaRange.FromString("application/x-protobuf")`が古い形式
  - コンストラクタを使えとの表示通り、`new MediaRange("application/x-protobuf")` へと変更
