### PR TITLE
Hosting Nancy on the Cloud (Intermediate)

### DIFF
--- a/InstantNancy/ToDoNancy/Bootstrapper.cs
+++ b/InstantNancy/ToDoNancy/Bootstrapper.cs
@@ -7,6 +7,7 @@ namespace ToDoNancy
 {
     using Nancy;
     using Nancy.Conventions;
+    using System.Configuration;
 
     public class Bootstrapper : DefaultNancyBootstrapper
     {
@@ -14,7 +15,9 @@ namespace ToDoNancy
         {
             base.ConfigureApplicationContainer(container);
 
-            var mongoDataStore = new MongoDataStore("mongodb://localhost:27017/todos");
+            var connectionString = System.Configuration.ConfigurationManager.AppSettings.Get("MONGOLAB_URI");
+            var mongoDataStore = new MongoDataStore(connectionString);
+            //var mongoDataStore = new MongoDataStore("mongodb://localhost:27017/todos");
             container.Register<IDataStore>(mongoDataStore);
         }
 

--- a/InstantNancy/ToDoNancy/Web.config
+++ b/InstantNancy/ToDoNancy/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   ASP.NET アプリケーションの構成方法の詳細については、
@@ -27,9 +27,14 @@
     <handlers>
       <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </handlers>
-  </system.webServer><appSettings>
+  </system.webServer>
+  <appSettings>
     <add key="webPages:Enabled" value="false" />
-  </appSettings><system.web.webPages.razor>
+    <!-- Add MongoDB URL in dev/azure environment  -->
+    <add key="MONGOLAB_URI" value="mongodb://localhost:27017/todos"/>
+    <!-- Add End -->
+  </appSettings>
+  <system.web.webPages.razor>
     <pages pageBaseType="Nancy.ViewEngines.Razor.NancyRazorViewBase">
       <namespaces>
         <add namespace="Nancy.ViewEngines.Razor" />

--- a/InstantNancy/ToDoNancyTests/DocumentationTests.cs
+++ b/InstantNancy/ToDoNancyTests/DocumentationTests.cs
@@ -11,6 +11,7 @@ namespace ToDoNancyTests
     using Xunit;
     using ToDoNancy;
 
+    [RunWith(typeof(KnownDevMachinesOnly))]
     public class DocumentationTests
     {
         [Fact]

--- a/InstantNancy/ToDoNancyTests/KnownDevMachinesOnly.cs
+++ b/InstantNancy/ToDoNancyTests/KnownDevMachinesOnly.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using Xunit.Sdk;
+
+    public class KnownDevMachinesOnly : ITestClassCommand
+    {
+        private TestClassCommand command;
+        private ITypeInfo typeInf;
+
+        public int ChooseNextTest(ICollection<IMethodInfo> testsLeftToRun)
+        {
+            return command != null ? command.ChooseNextTest(testsLeftToRun) : -1;
+        }
+
+        public Exception ClassFinish()
+        {
+            return command != null ? command.ClassFinish() : null;
+        }
+
+        public Exception ClassStart()
+        {
+            return command != null ? command.ClassStart() : null;
+        }
+
+        public IEnumerable<ITestCommand> EnumerateTestCommands(IMethodInfo testMethod)
+        {
+            return command != null ? command.EnumerateTestCommands(testMethod) : new ITestCommand[0];
+        }
+
+        public IEnumerable<IMethodInfo> EnumerateTestMethods()
+        {
+            return command != null ? command.EnumerateTestMethods() : new IMethodInfo[0];
+        }
+
+        public bool IsTestMethod(IMethodInfo testMethod)
+        {
+            return command != null ? command.IsTestMethod(testMethod) : false;
+        }
+
+        public object ObjectUnderTest
+        {
+            get { return command != null ? command.ObjectUnderTest : null; }
+        }
+
+        public ITypeInfo TypeUnderTest
+        {
+            get { return typeInf; }
+            set
+            {
+                typeInf = value;
+                if (IsDevMachine())
+                {
+                    command = new TestClassCommand(value);
+                }
+            }
+        }
+
+        public bool IsDevMachine()
+        {
+            if (System.Environment.OSVersion.Version.Minor == 1)
+            {
+                // Windows7と考える
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="DataStoreTests.cs" />
     <Compile Include="DocumentationTests.cs" />
     <Compile Include="HomeModuleTests.cs" />
+    <Compile Include="KnownDevMachinesOnly.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TodoModulesTests.cs" />
   </ItemGroup>

--- a/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
+++ b/InstantNancy/ToDoNancyTests/TodoModulesTests.cs
@@ -13,6 +13,7 @@ namespace ToDoNancyTests
     using MongoDB.Driver;
     using ToDoNancy;
 
+    [RunWith(typeof(KnownDevMachinesOnly))]
     public class TodoModulesTests
     {
         private Browser sut;

--- a/InstantNancy/ToDoNancyTests/app.config
+++ b/InstantNancy/ToDoNancyTests/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
@@ -7,6 +7,7 @@
   </configSections>
   <appSettings>
     <add key="webPages:Enabled" value="false" />
+    <add key="MONGOLAB_URI" value="mongodb://localhost:27017/todos"/>
   </appSettings>
   <system.web.webPages.razor>
     <pages pageBaseType="Nancy.ViewEngines.Razor.NancyRazorViewBase">


### PR DESCRIPTION
位置No.804～
- 開発マシンかのチェックは、書籍にある端末名からOS名へと変更
  - 開発環境のOSがWindows7だったため
    - それ以降だとクラウド上のサーバーOSと同じになる可能性あり
  - [ここらへん](https://github.com/thinkAmi-sandbox/syakyo_Instant_Nancy_Web_Development/blob/ab90fe6d90914555bcd4d49e5d3a43d63735e6ed/InstantNancy/ToDoNancyTests/KnownDevMachinesOnly.cs#L64)の`IsDevMachine`メソッドでOSを判定
- AppHarborではなく、Azure Websitesへとデプロイ
  - `Web.Release.config`に接続文字列を入れるのではなく、Azureのアプリケーション設定に接続文字列をセット
- テストを通すために、テストプロジェクトの`app.config`にMongoDBへの接続情報を記入
- デプロイ時にエラー内容を確認するため、以下をBootstrapperに追加

``` cs
protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
{
    base.ApplicationStartup(container, pipelines);
    StaticConfiguration.DisableErrorTraces = false;
}
```
#### Azureへのデプロイ
- AzureでWebsitesを作成
- AzureでローカルのGitをリポジトリとして追加
- ローカルのGitリポジトリにazureをremoteとして追加
- [MongoLab](https://mongolab.com)にてFreePlanで、データベース名を`todos`として作成
  - 本来ならAzureのMARKETPLACEで`MongoLab`を追加できるはずだが、Internal Server Errorのためできず
  - 念のため、ユーザーを新規作成して、パスワード設定
  - 接続文字列が表示されるので覚えておく
- スタートアッププロジェクトになるのを防ぐため、念のため、ソリューションから`HelloNancy`を削除
- Azureで、Websitesの構成 > アプリケーション設定に、MongoLabへ接続する文字列をセット
  - キーは`MONGOLAB_URI`、値はMongoLabで表示されたもの
- pushして、動作を確認
