### PR TITLE
Handling cross-cutting concerns - Before, After, and Error hooks (Intermediate)

### DIFF
--- a/InstantNancy/ToDoNancy/Bootstrapper.cs
+++ b/InstantNancy/ToDoNancy/Bootstrapper.cs
@@ -7,17 +7,34 @@ namespace ToDoNancy
 {
     using Nancy;
     using Nancy.Conventions;
+    using Nancy.Bootstrapper;
+    using NLog;
+    using NLog.Targets;
+    using NLog.Targets.Wrappers;
     using System.Configuration;
 
     public class Bootstrapper : DefaultNancyBootstrapper
     {
+        private NLog.Logger log = NLog.LogManager.GetLogger("RequestLogger");
+
+        protected override void ApplicationStartup(Nancy.TinyIoc.TinyIoCContainer container, Nancy.Bootstrapper.IPipelines pipelines)
+        {
+            base.ApplicationStartup(container, pipelines);
+
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(
+                new NLog.Targets.Wrappers.AsyncTargetWrapper(new NLog.Targets.EventLogTarget()));
+
+            LogAllRequests(pipelines);
+            LogAllResponseCodes(pipelines);
+            LogUnhandledExceptions(pipelines);
+        }
+
         protected override void ConfigureApplicationContainer(Nancy.TinyIoc.TinyIoCContainer container)
         {
             base.ConfigureApplicationContainer(container);
 
             var connectionString = System.Configuration.ConfigurationManager.AppSettings.Get("MONGOLAB_URI");
             var mongoDataStore = new MongoDataStore(connectionString);
-            //var mongoDataStore = new MongoDataStore("mongodb://localhost:27017/todos");
             container.Register<IDataStore>(mongoDataStore);
         }
 
@@ -27,6 +44,35 @@ namespace ToDoNancy
 
             Conventions.StaticContentsConventions.Add(
                 Nancy.Conventions.StaticContentConventionBuilder.AddDirectory("/docs", "Docs"));
+        }
+
+
+        //-----------------
+        private void LogAllRequests(Nancy.Bootstrapper.IPipelines pipelines)
+        {
+            pipelines.BeforeRequest += ctx =>
+            {
+                log.Info("Handling request {0} \"{1}\"", ctx.Request.Method, ctx.Request.Path);
+                return null;
+            };
+        }
+
+        private void LogAllResponseCodes(IPipelines pipelines)
+        {
+            pipelines.AfterRequest += ctx =>
+                log.Info("Responding {0} to {1} \"{2}\"",
+                    ctx.Response.StatusCode, ctx.Request.Method, ctx.Request.Path);
+        }
+
+        private void LogUnhandledExceptions(IPipelines pipelines)
+        {
+            pipelines.OnError.AddItemToEndOfPipeline((ctx, err) =>
+            {
+                log.ErrorException(string.Format(
+                    "Request {0} \"{1}\" failed",
+                    ctx.Request.Method, ctx.Request.Path), err);
+                return null;
+            });
         }
     }
 }

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -62,6 +62,9 @@
     <Reference Include="Nancy.ViewEngines.Razor">
       <HintPath>..\packages\Nancy.Viewengines.Razor.1.0.0\lib\net40\Nancy.ViewEngines.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="protobuf-net">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>

--- a/InstantNancy/ToDoNancy/Web.config
+++ b/InstantNancy/ToDoNancy/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   ASP.NET アプリケーションの構成方法の詳細については、
@@ -31,7 +31,7 @@
   <appSettings>
     <add key="webPages:Enabled" value="false" />
     <!-- Add MongoDB URL in dev/azure environment  -->
-    <add key="MONGOLAB_URI" value="mongodb://localhost:27017/todos"/>
+    <add key="MONGOLAB_URI" value="mongodb://localhost:27017/todos" />
     <!-- Add End -->
   </appSettings>
   <system.web.webPages.razor>

--- a/InstantNancy/ToDoNancy/packages.config
+++ b/InstantNancy/ToDoNancy/packages.config
@@ -9,5 +9,6 @@
   <package id="Nancy" version="1.0.0" targetFramework="net45" />
   <package id="Nancy.Hosting.Aspnet" version="1.0.0" targetFramework="net45" />
   <package id="Nancy.Viewengines.Razor" version="1.0.0" targetFramework="net45" />
+  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
 </packages>

--- a/InstantNancy/ToDoNancyTests/RequestLoggingTests.cs
+++ b/InstantNancy/ToDoNancyTests/RequestLoggingTests.cs
@@ -66,7 +66,7 @@ namespace ToDoNancyTests
             catch{}
             finally
             {
-                Assert.True(TryFindExptedErrorLog(actualLog, "Input string was not in a correct format."));
+                Assert.True(TryFindExptedErrorLog(actualLog, "入力文字列の形式が正しくありません。"));
             }
         }
 

--- a/InstantNancy/ToDoNancyTests/RequestLoggingTests.cs
+++ b/InstantNancy/ToDoNancyTests/RequestLoggingTests.cs
@@ -57,6 +57,32 @@ namespace ToDoNancyTests
         }
 
         [Fact]
+        public void ShouldLogMethod_post()
+        {
+            sut.Post("/");
+
+            Assert.True(TryFindExptedInfoLog(actualLog, "POST"));
+        }
+
+        [Fact]
+        public void ShoudLogMethod_put()
+        {
+            sut.Put("/");
+
+            Assert.True(TryFindExptedInfoLog(actualLog, "PUT"));
+        }
+
+        [Theory]
+        [InlineData("/")]
+        [InlineData("/todos/")]
+        public void ShouldNotLogErrorOnSuccessfulRequest(string path)
+        {
+            sut.Get(path);
+
+            Assert.False(TryFindExptedErrorLog(actualLog, ""));
+        }
+
+        [Fact]
         public void ShouldLogErrorOnFailingRequest()
         {
             try{

--- a/InstantNancy/ToDoNancyTests/RequestLoggingTests.cs
+++ b/InstantNancy/ToDoNancyTests/RequestLoggingTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using Nancy;
+    using Nancy.Testing;
+    using NLog;
+    using NLog.Config;
+    using NLog.Targets;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class RequestLoggingTests
+    {
+        private Nancy.Testing.Browser sut;
+        private NLog.Targets.MemoryTarget actualLog;
+        private const string infoRequestlogger = "|INFO|RequestLogger";
+        private const string errorRequestlogger = "|ERROR|RequestLogger";
+
+        public RequestLoggingTests()
+        {
+            sut = new Browser(new ToDoNancy.Bootstrapper());
+            OverrideNLogConfiguration();
+        }
+
+        private void OverrideNLogConfiguration()
+        {
+            actualLog = new MemoryTarget();
+            actualLog.Layout += "|${exception}";
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(actualLog, LogLevel.Info);
+        }
+
+        [Xunit.Extensions.Theory]
+        [Xunit.Extensions.InlineData("/")]
+        [InlineData("/todos/")]
+        [InlineData("/shouldnotbefound/")]
+        public void ShouldLogIncomingRequests(string path)
+        {
+            sut.Get(path);
+
+            Assert.True(TryFindExptedInfoLog(actualLog, "Handling request GET \"" + path + "\""));
+        }
+        
+        [Theory]
+        [InlineData("/", HttpStatusCode.OK)]
+        [InlineData("/todos/", HttpStatusCode.OK)]
+        [InlineData("/shouldnotbefound/", HttpStatusCode.NotFound)]
+        public void ShouldLogStatusCodeOffResponses(string path, HttpStatusCode expectedStatusCode)
+        {
+            sut.Get(path);
+
+            Assert.True(TryFindExptedInfoLog(actualLog, "Responding " + expectedStatusCode + " to GET \"" + path + "\""));
+        }
+
+        [Fact]
+        public void ShouldLogErrorOnFailingRequest()
+        {
+            try{
+                sut.Delete("/todos/illegal_item_id");
+            }
+            
+            catch{}
+            finally
+            {
+                Assert.True(TryFindExptedErrorLog(actualLog, "Input string was not in a correct format."));
+            }
+        }
+
+
+        //----------------
+        private static bool TryFindExptedInfoLog(MemoryTarget actualLog, string expected)
+        {
+            return TryFindExptedLogAtExpectedLevel(actualLog, expected, infoRequestlogger);
+        }
+
+        private static bool TryFindExptedErrorLog(MemoryTarget actualLog, string expected)
+        {
+            return TryFindExptedLogAtExpectedLevel(actualLog, expected, errorRequestlogger);
+        }
+
+        private static bool TryFindExptedLogAtExpectedLevel(
+            MemoryTarget actualLog, string expected, string requestloggerLevel)
+        {
+            var tryFindExptedLog = actualLog.Logs
+                .Where(s => s.Contains(requestloggerLevel))
+                .FirstOrDefault(s => s.Contains(expected));
+
+            if (tryFindExptedLog != null) return true;
+
+            Console.WriteLine(
+                "\"{0}\" not found in log filtered by \"{1}\":",
+                expected, requestloggerLevel);
+
+            Console.WriteLine(
+                actualLog.Logs
+                .Aggregate("[\n\t{0}\n", (acc, s1) => string.Format(acc, s1 + "\n\t{0}" )));
+
+            return false;
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="HomeModuleTests.cs" />
     <Compile Include="KnownDevMachinesOnly.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RequestLoggingTests.cs" />
     <Compile Include="TodoModulesTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -56,6 +56,9 @@
     <Reference Include="Nancy.ViewEngines.Razor">
       <HintPath>..\packages\Nancy.Viewengines.Razor.1.0.0\lib\net40\Nancy.ViewEngines.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="protobuf-net">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>

--- a/InstantNancy/ToDoNancyTests/app.config
+++ b/InstantNancy/ToDoNancyTests/app.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
@@ -7,7 +7,7 @@
   </configSections>
   <appSettings>
     <add key="webPages:Enabled" value="false" />
-    <add key="MONGOLAB_URI" value="mongodb://localhost:27017/todos"/>
+    <add key="MONGOLAB_URI" value="mongodb://localhost:27017/todos" />
   </appSettings>
   <system.web.webPages.razor>
     <pages pageBaseType="Nancy.ViewEngines.Razor.NancyRazorViewBase">

--- a/InstantNancy/ToDoNancyTests/packages.config
+++ b/InstantNancy/ToDoNancyTests/packages.config
@@ -7,6 +7,7 @@
   <package id="Nancy" version="1.0.0" targetFramework="net45" />
   <package id="Nancy.Testing" version="1.0.0" targetFramework="net45" />
   <package id="Nancy.Viewengines.Razor" version="1.0.0" targetFramework="net45" />
+  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />


### PR DESCRIPTION
位置No.875～
- 位置No898のテストコード`ShouldLogErrorOnFailingRequest`で日本語環境だとエラー内容が異なるため、通らないので、環境に合わせて修正
  - 書籍： Input string was not in a correct format
  - 日本語環境： 入力文字列の形式が正しくありません。
- サンプルコードには`ShouldNotLogErrorOnSuccessfulReqeust`というテストコードがあるが、書籍には記載されていない
- ロギングでは、`Nancy.Elmah`というNuGetパッケージもある
