### PR TITLE
Authenticating users (Intermediate)

### DIFF
--- a/InstantNancy/ToDoNancy/Bootstrapper.cs
+++ b/InstantNancy/ToDoNancy/Bootstrapper.cs
@@ -27,6 +27,8 @@ namespace ToDoNancy
             LogAllRequests(pipelines);
             LogAllResponseCodes(pipelines);
             LogUnhandledExceptions(pipelines);
+
+            SetCurrentUserWhenLoggedIn(pipelines);
         }
 
         protected override void ConfigureApplicationContainer(Nancy.TinyIoc.TinyIoCContainer container)
@@ -73,6 +75,24 @@ namespace ToDoNancy
                     ctx.Request.Method, ctx.Request.Path), err);
                 return null;
             });
+        }
+
+
+        private static void SetCurrentUserWhenLoggedIn(IPipelines pipelines)
+        {
+            pipelines.BeforeRequest += ctx =>
+            {
+                if (ctx.Request.Cookies.ContainsKey("todoUser"))
+                {
+                    ctx.CurrentUser = new TokenService().GetUserFromToken(
+                        ctx.Request.Cookies["todoUser"]);
+                }
+                else
+                {
+                    ctx.CurrentUser = User.Anonymous;
+                }
+                return null;
+            };
         }
     }
 }

--- a/InstantNancy/ToDoNancy/IDataStore.cs
+++ b/InstantNancy/ToDoNancy/IDataStore.cs
@@ -11,7 +11,7 @@ namespace ToDoNancy
         IEnumerable<Todo> GetAll();
         long Count { get; }
         bool TryAdd(Todo todo);
-        bool TryRemove(int id);
-        bool TryUpdate(Todo todo);
+        bool TryRemove(int id, string userName);
+        bool TryUpdate(Todo todo, string userName);
     }
 }

--- a/InstantNancy/ToDoNancy/MongoDataStore.cs
+++ b/InstantNancy/ToDoNancy/MongoDataStore.cs
@@ -28,7 +28,8 @@ namespace ToDoNancy
 
         public IEnumerable<Todo> GetAll()
         {
-            return todos.FindAllAs<Todo>();
+            var fields = typeof(Todo).GetProperties().Select(info => info.Name);
+            return todos.FindAllAs<Todo>().SetFields(fields.ToArray()).ToArray();
         }
 
         public bool TryAdd(Todo todo)
@@ -40,9 +41,9 @@ namespace ToDoNancy
             return true;
         }
 
-        public bool TryRemove(int id)
+        public bool TryRemove(int id, string userName)
         {
-            if (FindById(id) == null)
+            if (FindByIdAndUser(id, userName) == null)
                 return false;
 
             todos.Remove(Query.EQ("_id", id));
@@ -54,9 +55,18 @@ namespace ToDoNancy
             return todos.Find(Query.EQ("_id", id)).FirstOrDefault();
         }
 
-        public bool TryUpdate(Todo todo)
+        private BsonDocument FindByIdAndUser(long id, string userName)
         {
-            if (FindById(todo.id) == null)
+            return todos.Find(
+                    Query.And(
+                        Query.EQ("_id", id),
+                        Query.EQ("userName", userName)))
+                .FirstOrDefault();
+        }
+
+        public bool TryUpdate(Todo todo, string userName)
+        {
+            if (FindByIdAndUser(todo.id, userName) == null)
                 return false;
 
             todos.Save(todo);

--- a/InstantNancy/ToDoNancy/SocialAuthenticatoinCallbackProvider.cs
+++ b/InstantNancy/ToDoNancy/SocialAuthenticatoinCallbackProvider.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    using Nancy;
+    using Nancy.Cookies;
+    using Nancy.SimpleAuthentication;
+    public class SocialAuthenticatoinCallbackProvider
+        : Nancy.SimpleAuthentication.IAuthenticationCallbackProvider
+    {
+        public dynamic Process(
+            Nancy.NancyModule module,
+            Nancy.SimpleAuthentication.AuthenticateCallbackData callbackData)
+        {
+            module.Context.CurrentUser = new User
+            {
+                UserName = callbackData.AuthenticatedClient.UserInformation.UserName
+            };
+
+            return module.Response
+                .AsRedirect("/")
+                .WithCookie(new Nancy.Cookies.NancyCookie("todoUser",
+                    new ToDoNancy.TokenService().GetToken(module.Context.CurrentUser.UserName)));       
+        }
+
+        public dynamic OnRedirectToAuthenticationProviderError(
+            NancyModule module, string errorMessage)
+        {
+            return "login failed:" + errorMessage;
+        }
+    }
+}

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -132,6 +132,7 @@
     </Compile>
     <Compile Include="Todo.cs" />
     <Compile Include="TodoModule.cs" />
+    <Compile Include="User.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -68,6 +68,12 @@
     <Reference Include="protobuf-net">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
+    <Reference Include="RestSharp">
+      <HintPath>..\packages\RestSharp.104.1\lib\net4\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleAuthentication.Core">
+      <HintPath>..\packages\SimpleAuthentication.Core.0.3.14\lib\net40\SimpleAuthentication.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/InstantNancy/ToDoNancy/ToDoNancy.csproj
+++ b/InstantNancy/ToDoNancy/ToDoNancy.csproj
@@ -59,6 +59,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Nancy.Hosting.Aspnet.1.0.0\lib\net40\Nancy.Hosting.Aspnet.dll</HintPath>
     </Reference>
+    <Reference Include="Nancy.SimpleAuthentication">
+      <HintPath>..\packages\Nancy.SimpleAuthentication.0.3.14\lib\net40\Nancy.SimpleAuthentication.dll</HintPath>
+    </Reference>
     <Reference Include="Nancy.ViewEngines.Razor">
       <HintPath>..\packages\Nancy.Viewengines.Razor.1.0.0\lib\net40\Nancy.ViewEngines.Razor.dll</HintPath>
     </Reference>
@@ -136,8 +139,10 @@
     <Compile Include="RazorConfig.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="SocialAuthenticatoinCallbackProvider.cs" />
     <Compile Include="Todo.cs" />
     <Compile Include="TodoModule.cs" />
+    <Compile Include="TokenService.cs" />
     <Compile Include="User.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/InstantNancy/ToDoNancy/Todo.cs
+++ b/InstantNancy/ToDoNancy/Todo.cs
@@ -7,6 +7,7 @@ namespace ToDoNancy
 {
     public class Todo
     {
+        public string userName { get; set; }
         public long id { get; set; }
         public string title { get; set; }
         public int order { get; set; }

--- a/InstantNancy/ToDoNancy/TodoModule.cs
+++ b/InstantNancy/ToDoNancy/TodoModule.cs
@@ -15,19 +15,26 @@ namespace ToDoNancy
 
         public TodoModule(IDataStore todoStore) : base("todos")
         {
-            Get["/"] = _ => 
+            Get["/"] = _ =>
                 Negotiate
                     // `.WithModel(todoStore.GetAll())`だと、例外発生
                     // MongoDB.Driver.MongoCursor`1[ToDoNancy.Todo]' のオブジェクトを型 'ToDoNancy.Todo[]' にキャストできません。
                     // `.WithModel(todoStore.GetAll().ToArray())`でArrayを返すように変更
-                    .WithModel(todoStore.GetAll().ToArray())
-                    //.WithModel(todoStore.GetAll())
+                    //.WithModel(todoStore.GetAll())            // NG
+                    //.WithModel(todoStore.GetAll().ToArray()   // OK
+
+                    // No.1058で以下のように修正が入ると、エラーにならない
+                    .WithModel(todoStore.GetAll()
+                        .Where(todo => todo.userName == Context.CurrentUser.UserName)
+                        .ToArray())
+
                     .WithView("Todos");
 
             Post["/"] = _ =>
             {
                 // TodoオブジェクトをPOSTのBodyにバインディング
                 var newTodo = this.Bind<Todo>();
+                newTodo.userName = Context.CurrentUser.UserName;
 
                 if (newTodo.id == 0)
                 {
@@ -46,14 +53,20 @@ namespace ToDoNancy
             {
                 var updatedTodo = this.Bind<Todo>();
 
-                if (!todoStore.TryUpdate(updatedTodo)) return HttpStatusCode.NotFound;
-
+                if (!todoStore.TryUpdate(updatedTodo, Context.CurrentUser.UserName))
+                {
+                    return HttpStatusCode.NotFound;
+                }
+                
                 return updatedTodo;
             };
 
             Delete["/{id}/"] = p =>
             {
-                if (!todoStore.TryRemove(p.id)) return HttpStatusCode.NotFound;
+                if (!todoStore.TryRemove(p.id, Context.CurrentUser.UserName))
+                {
+                    return HttpStatusCode.NotFound;
+                }
 
                 return HttpStatusCode.OK;
             };

--- a/InstantNancy/ToDoNancy/TokenService.cs
+++ b/InstantNancy/ToDoNancy/TokenService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    using Nancy.Security;
+    public class TokenService
+    {
+        public string GetToken(string userName)
+        {
+            return userName;
+        }
+
+        public Nancy.Security.IUserIdentity GetUserFromToken(string token)
+        {
+            return new ToDoNancy.User { UserName = token };
+        }
+    }
+}

--- a/InstantNancy/ToDoNancy/User.cs
+++ b/InstantNancy/ToDoNancy/User.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ToDoNancy
+{
+    using Nancy.Security;
+    public class User : IUserIdentity
+    {
+        public static IUserIdentity Anonymous { get; private set; }
+
+        public string UserName { get; set; }
+        public IEnumerable<string> Claims { get; private set; }
+
+        static User()
+        {
+            Anonymous = new User { UserName = "anonymous" };
+        }
+
+    }
+}

--- a/InstantNancy/ToDoNancy/Views/Todos.cshtml
+++ b/InstantNancy/ToDoNancy/Views/Todos.cshtml
@@ -6,6 +6,8 @@ Nancy.ViewEngines.Razor.NancyRazorViewBase<Todo[]>
         <title>Todos</title>
     </head>
     <body>
+        <a href="/authentication/redirect/twitter">Login with Twitter</a>
+
         <h1>All todos</h1>
         <table>
             <th>Title</th>

--- a/InstantNancy/ToDoNancy/Web.config
+++ b/InstantNancy/ToDoNancy/Web.config
@@ -10,6 +10,7 @@
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
       <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
     </sectionGroup>
+    <section name="authenticationProviders" type="SimpleAuthentication.Core.Config.ProviderConfiguration, SimpleAuthentication.Core" />
   </configSections>
     <system.web>
       <compilation debug="true" targetFramework="4.5"><buildProviders>
@@ -57,4 +58,12 @@
  </dependentAssembly>
 </assemblyBinding>
 </runtime>
+<authenticationProviders>
+<providers>
+<add name="Facebook" key="please-enter-your-real-value" secret="please-enter-your-real-value" />
+<add name="Google" key="please-enter-your-real-value" secret="please-enter-your-real-value" />
+<add name="Twitter" key="please-enter-your-real-value" secret="please-enter-your-real-value" />
+<add name="WindowsLive" key="please-enter-your-real-value" secret="please-enter-your-real-value" />
+</providers>
+</authenticationProviders>
 </configuration>

--- a/InstantNancy/ToDoNancy/packages.config
+++ b/InstantNancy/ToDoNancy/packages.config
@@ -8,7 +8,10 @@
   <package id="mongocsharpdriver" version="1.9.2" targetFramework="net45" />
   <package id="Nancy" version="1.0.0" targetFramework="net45" />
   <package id="Nancy.Hosting.Aspnet" version="1.0.0" targetFramework="net45" />
+  <package id="Nancy.SimpleAuthentication" version="0.3.14" targetFramework="net45" />
   <package id="Nancy.Viewengines.Razor" version="1.0.0" targetFramework="net45" />
   <package id="NLog" version="3.2.0.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="RestSharp" version="104.1" targetFramework="net45" />
+  <package id="SimpleAuthentication.Core" version="0.3.14" targetFramework="net45" />
 </packages>

--- a/InstantNancy/ToDoNancyTests/AuthenticationTests.cs
+++ b/InstantNancy/ToDoNancyTests/AuthenticationTests.cs
@@ -38,5 +38,18 @@ namespace ToDoNancyTests
             Assert.Contains("todoUser", actual.Cookies.Select(cookie => cookie.Name));
             Assert.Contains(userNameToken, actual.Cookies.Select(cookie => cookie.Value));
         }
+
+        [Fact]
+        public void Should_set_user_identity_when_cookie_is_set()
+        {
+            var expected = "chr_horsdal";
+            var userNameToken = new ToDoNancy.TokenService().GetToken(expected);
+
+            var sut = new Browser(new ToDoNancy.Bootstrapper());
+
+            sut.Get("/testing", with => with.Cookie("todoUser", userNameToken));
+
+            Assert.Equal(expected, TestingAuthenticationModule.actualUser.UserName);
+        }
     }
 }

--- a/InstantNancy/ToDoNancyTests/AuthenticationTests.cs
+++ b/InstantNancy/ToDoNancyTests/AuthenticationTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using Nancy;
+    using Nancy.Testing;
+    using Nancy.SimpleAuthentication;
+    using SimpleAuthentication.Core;
+    using Xunit;
+    using ToDoNancy;
+
+    public class AuthenticationTests
+    {
+        [Xunit.Fact]
+        public void Should_redirect_to_root_on_social_authc_callback()
+        {
+            new Nancy.Testing.Browser(new ToDoNancy.Bootstrapper()).Get("/testing");
+            var userNameToken = new ToDoNancy.TokenService().GetToken("chr_horsdal");
+            var callbackData = new Nancy.SimpleAuthentication.AuthenticateCallbackData
+            {
+                AuthenticatedClient = new SimpleAuthentication.Core.AuthenticatedClient("")
+                {
+                    UserInformation = new SimpleAuthentication.Core.UserInformation
+                    {
+                        UserName = "chr_horsdal"
+                    }
+                }
+            };
+
+            var sut = new ToDoNancy.SocialAuthenticatoinCallbackProvider();
+
+            var actual = (Response)sut.Process(TestingAuthenticationModule.actualModule, callbackData);
+
+            Assert.Contains("todoUser", actual.Cookies.Select(cookie => cookie.Name));
+            Assert.Contains(userNameToken, actual.Cookies.Select(cookie => cookie.Value));
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/TestingAuthenticationModule.cs
+++ b/InstantNancy/ToDoNancyTests/TestingAuthenticationModule.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using Nancy;
+    using Nancy.Security;
+    public class TestingAuthenticationModule : Nancy.NancyModule
+    {
+        public static Nancy.Security.IUserIdentity actualUser;
+        public static TestingAuthenticationModule actualModule;
+
+        public TestingAuthenticationModule()
+        {
+            Get["/testing"] = _ =>
+            {
+                actualUser = Context.CurrentUser;
+                actualModule = this;
+                return HttpStatusCode.OK;
+            };
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="RequestLoggingTests.cs" />
     <Compile Include="TestingAuthenticationModule.cs" />
     <Compile Include="TodoModulesTests.cs" />
+    <Compile Include="UserSpecificTodoTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
+++ b/InstantNancy/ToDoNancyTests/ToDoNancyTests.csproj
@@ -49,6 +49,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Nancy.1.0.0\lib\net40\Nancy.dll</HintPath>
     </Reference>
+    <Reference Include="Nancy.SimpleAuthentication">
+      <HintPath>..\packages\Nancy.SimpleAuthentication.0.3.14\lib\net40\Nancy.SimpleAuthentication.dll</HintPath>
+    </Reference>
     <Reference Include="Nancy.Testing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Nancy.Testing.1.0.0\lib\net40\Nancy.Testing.dll</HintPath>
@@ -61,6 +64,12 @@
     </Reference>
     <Reference Include="protobuf-net">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp">
+      <HintPath>..\packages\RestSharp.104.1\lib\net4\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleAuthentication.Core">
+      <HintPath>..\packages\SimpleAuthentication.Core.0.3.14\lib\net40\SimpleAuthentication.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -82,12 +91,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assertions.cs" />
+    <Compile Include="AuthenticationTests.cs" />
     <Compile Include="DataStoreTests.cs" />
     <Compile Include="DocumentationTests.cs" />
     <Compile Include="HomeModuleTests.cs" />
     <Compile Include="KnownDevMachinesOnly.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestLoggingTests.cs" />
+    <Compile Include="TestingAuthenticationModule.cs" />
     <Compile Include="TodoModulesTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/InstantNancy/ToDoNancyTests/UserSpecificTodoTests.cs
+++ b/InstantNancy/ToDoNancyTests/UserSpecificTodoTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToDoNancyTests
+{
+    using Nancy;
+    using Nancy.Testing;
+    using FakeItEasy;
+    using Xunit;
+    using Xunit.Extensions;
+    using ToDoNancy;
+    public class UserSpecificTodoTests
+    {
+        private const string UserName = "Alice";
+        private readonly Nancy.Testing.Browser sut;
+        private readonly ToDoNancy.IDataStore fakeDataStore;
+
+        public UserSpecificTodoTests()
+        {
+            fakeDataStore = FakeItEasy.A.Fake<IDataStore>();
+            sut = new Browser(with =>
+            {
+                with.Module<TodoModule>();
+                with.ApplicationStartup((contaner, pipelines) =>
+                {
+                    contaner.Register(fakeDataStore);
+                    pipelines.BeforeRequest += ctx =>
+                    {
+                        ctx.CurrentUser = new User { UserName = UserName };
+                        return null;
+                    };
+                });
+            });
+        }
+
+        [Xunit.Extensions.Theory]
+        [Xunit.Extensions.InlineData(0, 0, 0)]
+        [InlineData(0, 10, 0)]
+        [InlineData(0, 0, 10)]
+        [InlineData(0, 10, 10)]
+        [InlineData(1, 0, 0)]
+        [InlineData(1, 10, 0)]
+        [InlineData(1, 0, 10)]
+        [InlineData(1, 10, 10)]
+        [InlineData(42, 0, 0)]
+        [InlineData(42, 10, 0)]
+        [InlineData(42, 0, 10)]
+        [InlineData(42, 10, 10)]
+        public void Should_only_get_user_own_todos(
+            int nofTodosForUser,
+            int nofTodosForAnonymousUser,
+            int nofTodosForOtherUser)
+        {
+            var todosForUser = Enumerable.Range(0, nofTodosForUser)
+                .Select(i => new Todo { id = i, userName = UserName });
+
+            var todosForAnonymousUser = Enumerable.Range(0, nofTodosForAnonymousUser)
+                .Select(i => new Todo { id = i });
+
+            var todosForOtherUser = Enumerable.Range(0, nofTodosForOtherUser)
+                .Select(i => new Todo { id = i, userName = "Bob" });
+
+            A.CallTo(() => fakeDataStore.GetAll())
+                .Returns(todosForUser.Concat(todosForAnonymousUser.Concat(todosForOtherUser)));
+
+            var actual = sut.Get("/todos/", with => with.Accept("application/json"));
+
+            var actualBody = actual.Body.DeserializeJson<Todo[]>();
+
+            Assert.Equal(nofTodosForUser, actualBody.Length);
+        }
+    }
+}

--- a/InstantNancy/ToDoNancyTests/packages.config
+++ b/InstantNancy/ToDoNancyTests/packages.config
@@ -5,10 +5,13 @@
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="mongocsharpdriver" version="1.9.2" targetFramework="net45" />
   <package id="Nancy" version="1.0.0" targetFramework="net45" />
+  <package id="Nancy.SimpleAuthentication" version="0.3.14" targetFramework="net45" />
   <package id="Nancy.Testing" version="1.0.0" targetFramework="net45" />
   <package id="Nancy.Viewengines.Razor" version="1.0.0" targetFramework="net45" />
   <package id="NLog" version="3.2.0.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="RestSharp" version="104.1" targetFramework="net45" />
+  <package id="SimpleAuthentication.Core" version="0.3.14" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
位置No.953～
- 書籍では`Nancy.Authentication.WorldDomination`を使っているが、NuGetパッケージからは削除済
  - [NuGet Gallery | WorldDomination: Nancy Web Authentication 0.19.2](http://www.nuget.org/packages/Nancy.Authentication.WorldDomination/)
  - WorldDomination自体もNuGetの更新が停止しているのと、プロジェクトページが削除されている
    - [NuGet Gallery | WorldDomination: Web Authentication 1.0.1](http://www.nuget.org/packages/WorldDomination.Web.Authentication/)
  - `Nancy.SimpleAuthentication`で置き換えたとのこと
    - [oauth - How do I manage my authentication with WorldDomination and Nancy? - Stack Overflow](http://stackoverflow.com/questions/18047615/how-do-i-manage-my-authentication-with-worlddomination-and-nancy)
- No.992で、`Response.AddCookie`を使っているが古い形式
  - 代わりに `Response.WithCookie`を使う
- No.985で`TestingModule`がいきなり出てきて迷った
  - サンプルコードの`AuthenticationTests.cs`の一番最後に`TestingModule`クラスがあった
  - 分かりにくかったので、`TestingAuthenticationModule.cs`として別ファイルのクラスに切り出した
- No.1008にもある通り、`TokenService`クラスはセキュアではなくプロダクションでは使わないこと
- Bootstrapperで、`context.Request.Cookies.ContainsKey`を使ってCookieを読む
- No.1041で、 `new Todo { ... userName = ... }`とあるが、ここまでにTodoクラスのプロパティ`userName`を追加する記載はなかった
  - 追加しないとコンパイルが通らないので、プロパティ`userName`を追加しておく
- No.1050で、`MongoDatastore`の変更に言及してるが、本文では変更後のコードが掲載されていないので、サンプルコードを実装しないとコンパイルエラーになる
